### PR TITLE
add MS-Office, Python internal update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ Currently including:
 - 🧶 Yarn (`yarn`)
 - 🐍 Python 2.7 and 3 (`pip`)
 - 🔵 Applications in the Appstore (`mas`)
+- 📚 Microsoft Office (`msupdate`)
 - 🖥 MacOS Operating System Updates/Patches (`softwareupdate`)
 

--- a/update-all.sh
+++ b/update-all.sh
@@ -70,17 +70,19 @@ update-yarn() {
 
 update-pip2() {
     if ! which pip2 &>/dev/null; then return; fi
+    if ! which python2 &>/dev/null; then return; fi
 
     echo -e "\n${GREEN}Updating Python 2.7.X pips${CLEAR}"
-    python2 -c "import pkg_resources; from subprocess import call; packages = [dist.project_name for dist in pkg_resources.working_set]; call('pip2 install --upgrade ' + ' '.join(packages), shell=True)"
+    python2 -c "import pkg_resources; from subprocess import call; packages = [dist.project_name for dist in pkg_resources.working_set]; call('pip install --upgrade ' + ' '.join(packages), shell=True)"
     #pip2 list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip2 install -U
 }
 
 update-pip3() {
     if ! which pip3 &>/dev/null; then return; fi
+    if ! which python3 &>/dev/null; then return; fi
 
     echo -e "\n${GREEN}Updating Python 3.X pips${CLEAR}"
-    python3 -c "import pkg_resources; from subprocess import call; packages = [dist.project_name for dist in pkg_resources.working_set]; call('pip3 install --upgrade ' + ' '.join(packages), shell=True)"
+    python3 -c "import pkg_resources; from subprocess import call; packages = [dist.project_name for dist in pkg_resources.working_set]; call('pip install --upgrade ' + ' '.join(packages), shell=True)"
     #pip3 list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip3 install -U
 }
 
@@ -117,3 +119,4 @@ update-all() {
 
 # COMMENT OUT IF SOURCING
 update-all
+

--- a/update-all.sh
+++ b/update-all.sh
@@ -31,8 +31,7 @@ update-brew() {
     brew cleanup -s
 
     echo -e "\n${GREEN}Updating Brew Casks${CLEAR}"
-    brew cask outdated
-    brew cask upgrade
+    brew cu -ay --no-brew-update
     brew cleanup -s
 
     echo -e "\n${GREEN}Brew Diagnostics${CLEAR}"
@@ -73,14 +72,16 @@ update-pip2() {
     if ! which pip2 &>/dev/null; then return; fi
 
     echo -e "\n${GREEN}Updating Python 2.7.X pips${CLEAR}"
-    pip2 freeze - local | grep -v ‘^\-e’ | cut -d = -f 1 | xargs pip2 install -U
+    python2 -c "import pkg_resources; from subprocess import call; packages = [dist.project_name for dist in pkg_resources.working_set]; call('pip2 install --upgrade ' + ' '.join(packages), shell=True)"
+    #pip2 list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip2 install -U
 }
 
 update-pip3() {
     if ! which pip3 &>/dev/null; then return; fi
 
     echo -e "\n${GREEN}Updating Python 3.X pips${CLEAR}"
-    pip3 freeze - local | grep -v ‘^\-e’ | cut -d = -f 1 | xargs pip3 install -U
+    python3 -c "import pkg_resources; from subprocess import call; packages = [dist.project_name for dist in pkg_resources.working_set]; call('pip3 install --upgrade ' + ' '.join(packages), shell=True)"
+    #pip3 list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip3 install -U
 }
 
 update-app_store() {
@@ -96,6 +97,11 @@ update-macos() {
     softwareupdate -i -a
 }
 
+update-office() {
+    echo -e "\n${GREEN}Updating MS-Office${CLEAR}"
+    /Library/Application\ Support/Microsoft/MAU2.0/Microsoft\ AutoUpdate.app/Contents/MacOS/msupdate --install
+}
+
 update-all() {
     update-brew
     update-atom
@@ -105,9 +111,9 @@ update-all() {
     update-pip2
     update-pip3
     update-app_store
+    update-office
     update-macos
 }
 
 # COMMENT OUT IF SOURCING
 update-all
-


### PR DESCRIPTION
Hi!

I added the internal Microsoft Office Updater and the python internal update procedure, which will update all packages. The current version might need to be run multiple times.

We can definitely discuss the `brew cu -ay --no-brew-update` part. This is my personal way, I am not sure if `brew upgrade` does the same by now.