### PR TITLE
Improve `update_app_store()` function

### DIFF
--- a/update-all.sh
+++ b/update-all.sh
@@ -116,7 +116,7 @@ update_app_store() {
         return
     fi
 
-    mas outdated | while read -r app; do mas upgrade "$app"; done
+    mas upgrade
 }
 
 update_macos() {


### PR DESCRIPTION
This PR uses the command `mas upgrade` instead of the more complicated `mas outdated | while read -r app; do mas upgrade "$app"; done` while still doing the exact same.
