### PR TITLE
Disable Gem on Builtin Gem

### DIFF
--- a/update-all.sh
+++ b/update-all.sh
@@ -69,8 +69,13 @@ update_vscode() {
 update_gem() {
     println "Updating Gems"
 
-    if ! check_command gem; then
-        return
+    # Get the path of the `gem` command
+    GEM_PATH=$(which gem)
+
+    # Check if the path does not match the expected path
+    if [ "$GEM_PATH" = "/usr/local/opt/ruby/bin/gem" ]; then
+    	print_err "gem is not installed."
+	return
     fi
 
     gem update --user-install && gem cleanup --user-install


### PR DESCRIPTION
Prevents the gem updates from running when gem hasn't been installed outside of the builtin macOS package. Errors occur when attempting builtin verison.