### PR TITLE
Revert to sequential execution + flags

### DIFF
--- a/macup/macup.go
+++ b/macup/macup.go
@@ -1,8 +1,7 @@
 package macup
 
 import (
-	"io"
-	"sync"
+	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
 )
@@ -11,7 +10,7 @@ import (
 type Update struct {
 	Name        string
 	Description string
-	Run         func(writer io.Writer)
+	Run         func()
 }
 
 // Config represents the user's selections.
@@ -30,21 +29,18 @@ var Updates = []Update{
 	{"macos", "Update macOS system", UpdateMacOS},
 }
 
-// Run runs the selected update functions.
-func Run(writer io.Writer, selectedUpdates []string) {
-	var wg sync.WaitGroup
+func Run(selectedUpdates []string) {
 	for _, updateName := range selectedUpdates {
 		for _, u := range Updates {
 			if u.Name == updateName {
-				wg.Add(1)
 				go func(u Update) {
-					defer wg.Done()
-					u.Run(writer)
+					fmt.Printf("Starting: %s\n", u.Description)
+					u.Run()
+					fmt.Printf("Finished: %s\n", u.Description)
 				}(u)
 			}
 		}
 	}
-	wg.Wait()
 }
 
 // SelectUpdates prompts the user to select which updates to run.

--- a/macup/test/macup_test.go
+++ b/macup/test/macup_test.go
@@ -4,19 +4,18 @@ package macup
 
 import (
 	"bytes"
-	"io"
 	"testing"
 )
 
 // Helper to capture output
-func captureOutput(f func(io.Writer)) string {
+func captureOutput(f func(io.)) string {
 	buf := &bytes.Buffer{}
 	f(buf)
 	return buf.String()
 }
 
 func TestPrintlnGreen(t *testing.T) {
-	out := captureOutput(func(w io.Writer) { printlnGreen(w, "Hello") })
+	out := captureOutput(func(w io.) { printlnGreen(w, "Hello") })
 	if !bytes.Contains([]byte(out), []byte("Hello")) {
 		t.Errorf("Expected output to contain 'Hello', got: %s", out)
 	}

--- a/macup/update.go
+++ b/macup/update.go
@@ -1,85 +1,84 @@
 package macup
 
 import (
-	"io"
 	"os/exec"
 	"strings"
 )
 
 // UpdateBrew updates Homebrew formulas and perform diagnostics.
-func UpdateBrew(writer io.Writer) {
-	printlnGreen(writer, "Updating Brew Formulas")
-	if checkCommand(writer, "brew") {
-		runCommand(writer, "brew", "update")
-		runCommand(writer, "brew", "upgrade")
-		runCommand(writer, "brew", "cleanup", "-s")
-		printlnGreen(writer, "Brew Diagnostics")
-		runCommand(writer, "brew", "doctor")
-		runCommand(writer, "brew", "missing")
+func UpdateBrew() {
+	printlnGreen("Updating Brew Formulas")
+	if checkCommand("brew") {
+		runCommand("brew", "update")
+		runCommand("brew", "upgrade")
+		runCommand("brew", "cleanup", "-s")
+		printlnGreen("Brew Diagnostics")
+		runCommand("brew", "doctor")
+		runCommand("brew", "missing")
 	}
 }
 
 // UpdateVSCodeExt updates VSCode extensions.
-func UpdateVSCodeExt(writer io.Writer) {
-	printlnGreen(writer, "Updating VSCode Extensions")
-	if checkCommand(writer, "code") {
-		runCommand(writer, "code", "--update-extensions")
+func UpdateVSCodeExt() {
+	printlnGreen("Updating VSCode Extensions")
+	if checkCommand("code") {
+		runCommand("code", "--update-extensions")
 	}
 }
 
 // UpdateGem updates Ruby gems and clean up.
-func UpdateGem(writer io.Writer) {
-	printlnGreen(writer, "Updating Gems")
+func UpdateGem() {
+	printlnGreen("Updating Gems")
 	gemPath, err := exec.LookPath("gem")
 	if err != nil || gemPath == k_gemCmdPath {
-		printlnYellow(writer, "gem is not installed.")
+		printlnYellow("gem is not installed.")
 		return
 	}
-	runCommand(writer, "gem", "update", "--user-install")
-	runCommand(writer, "gem", "cleanup", "--user-install")
+	runCommand("gem", "update", "--user-install")
+	runCommand("gem", "cleanup", "--user-install")
 }
 
 // UpdateNodePkg updates global Node.js, npm, and Yarn packages.
-func UpdateNodePkg(writer io.Writer) {
-	printlnGreen(writer, "Updating Node Packages")
-	if checkCommand(writer, "node") {
-		printlnGreen(writer, "Updating Npm Packages")
-		if checkCommand(writer, "npm") {
-			runCommand(writer, "npm", "update", "-g")
+func UpdateNodePkg() {
+	printlnGreen("Updating Node Packages")
+	if checkCommand("node") {
+		printlnGreen("Updating Npm Packages")
+		if checkCommand("npm") {
+			runCommand("npm", "update", "-g")
 		}
 
-		printlnGreen(writer, "Updating Yarn Packages")
-		if checkCommand(writer, "yarn") {
-			runCommand(writer, "yarn", "global", "upgrade", "--latest")
+		printlnGreen("Updating Yarn Packages")
+		if checkCommand("yarn") {
+			runCommand("yarn", "global", "upgrade", "--latest")
 		}
 	}
 }
 
 // UpdateCargo updates Rust Cargo crates by reinstalling each listed crate.
-func UpdateCargo(writer io.Writer) {
-	printlnGreen(writer, "Updating Rust Cargo Crates")
-	if checkCommand(writer, "cargo") {
+func UpdateCargo() {
+	printlnGreen("Updating Rust Cargo Crates")
+	if checkCommand("cargo") {
 		out, _ := exec.Command("cargo", "install", "--list").Output()
 		lines := strings.SplitSeq(string(out), "\n")
 		for line := range lines {
 			if fields := strings.Fields(line); len(fields) > 0 {
 				name := fields[0]
-				runCommand(writer, "cargo", "install", name)
+				runCommand("cargo", "install", name)
 			}
 		}
 	}
 }
 
 // UpdateAppStore updates Mac App Store applications.
-func UpdateAppStore(writer io.Writer) {
-	printlnGreen(writer, "Updating App Store Applications")
-	if checkCommand(writer, "mas") {
-		runCommand(writer, "mas", "upgrade")
+func UpdateAppStore() {
+	printlnGreen("Updating App Store Applications")
+	if checkCommand("mas") {
+		runCommand("mas", "upgrade")
 	}
 }
 
 // UpdateMacOS updates macOS system software.
-func UpdateMacOS(writer io.Writer) {
-	printlnGreen(writer, "Updating MacOS")
-	runCommand(writer, "softwareupdate", "-i", "-a")
+func UpdateMacOS() {
+	printlnGreen("Updating MacOS")
+	runCommand("softwareupdate", "-i", "-a")
 }

--- a/macup/utils.go
+++ b/macup/utils.go
@@ -3,7 +3,6 @@ package macup
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -25,32 +24,32 @@ const (
 )
 
 // printlnGreen prints a message in green color with a newline.
-func printlnGreen(writer io.Writer, msg string) {
-	fmt.Fprintf(writer, "\n%s%s%s\n", k_green, msg, k_clear)
+func printlnGreen(msg string) {
+	fmt.Fprintf(os.Stdout, "\n%s%s%s\n", k_green, msg, k_clear)
 }
 
 // printlnRed prints a message in red color (no newline).
-func printlnRed(writer io.Writer, msg string) {
-	fmt.Fprintf(writer, "%s%s%s", k_red, msg, k_clear)
+func printlnRed(msg string) {
+	fmt.Fprintf(os.Stdout, "%s%s%s", k_red, msg, k_clear)
 }
 
 // printlnYellow prints a message in yellow color (no newline).
-func printlnYellow(writer io.Writer, msg string) {
-	fmt.Fprintf(writer, "%s%s%s", k_yellow, msg, k_clear)
+func printlnYellow(msg string) {
+	fmt.Fprintf(os.Stdout, "%s%s%s", k_yellow, msg, k_clear)
 }
 
 // checkCommand checks if a command exists in `PATH`, print warning if not.
-func checkCommand(writer io.Writer, cmd string) bool {
+func checkCommand(cmd string) bool {
 	_, err := exec.LookPath(cmd)
 	if err != nil {
-		printlnYellow(writer, cmd+" is not installed.")
+		printlnYellow(cmd + " is not installed.")
 		return false
 	}
 	return true
 }
 
-// runCommand runs a shell command and directs its output to writer.
-func runCommand(writer io.Writer, name string, args ...string) {
+// runCommand runs a shell command and directs its output to .
+func runCommand(name string, args ...string) {
 	// Allow only specific commands
 	allowedCommands := map[string]bool{
 		"brew":           true,
@@ -64,22 +63,22 @@ func runCommand(writer io.Writer, name string, args ...string) {
 	}
 
 	if !allowedCommands[name] {
-		printlnRed(writer, "Command not allowed: "+name)
+		printlnRed("Command not allowed: " + name)
 		return
 	}
 	// Optionally validate arguments (e.g., no special characters)
 	for _, arg := range args {
 		if strings.ContainsAny(arg, "&|;$><") {
-			printlnRed(writer, "Invalid Argument: "+arg)
+			printlnRed("Invalid Argument: " + arg)
 			return
 		}
 	}
 
 	cmd := exec.Command(name, args...)
-	cmd.Stdout = writer
-	cmd.Stderr = writer
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		printlnRed(writer, "Error running command: "+err.Error())
+
 	}
 }
 
@@ -91,7 +90,7 @@ func CheckInternet() bool {
 
 	resp, err := client.Get(k_testURL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "\n%s%s%s\n", k_red, "⚠️ No Internet Connection!!!", k_clear)
+		printlnRed("⚠️ No Internet Connection!!!")
 		return false
 	}
 	defer resp.Body.Close()

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"macup/macup"
 	"os"
@@ -9,6 +10,10 @@ import (
 
 // Entry point of the update script
 func main() {
+	// Define and parse the --yes flag
+	yes := flag.Bool("yes", false, "Use previous selections without prompting")
+	flag.Parse()
+
 	// Check for internet connectivity before proceeding
 	if !macup.CheckInternet() {
 		os.Exit(1)
@@ -22,17 +27,26 @@ func main() {
 	}
 
 	// Prompt the user to select updates
-	selectedUpdates, err := macup.SelectUpdates(config)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error selecting updates: %v\n", err)
-		os.Exit(1)
-	}
+	var selectedUpdates []string
+	if *yes && len(config.SelectedUpdates) > 0 {
+		selectedUpdates = config.SelectedUpdates
+	} else {
+		if *yes {
+			println("No previous updates selected. Prompting for selection.")
+		}
+		var err error
+		selectedUpdates, err = macup.SelectUpdates(config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error selecting updates: %v\n", err)
+			os.Exit(1)
+		}
 
-	// Save the user's selections
-	config.SelectedUpdates = selectedUpdates
-	if err := config.SaveConfig(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
-		os.Exit(1)
+		// Save the user's selections
+		config.SelectedUpdates = selectedUpdates
+		if err := config.SaveConfig(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Run the selected updates

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"macup/macup"
 	"os"
-	"sync"
 )
 
 // Entry point of the update script
@@ -37,25 +36,17 @@ func main() {
 	}
 
 	// Run the selected updates
-	var wg sync.WaitGroup
 	buffers := make(map[string]*bytes.Buffer)
 	for _, updateName := range selectedUpdates {
 		buffers[updateName] = &bytes.Buffer{}
 	}
-
 	for _, updateName := range selectedUpdates {
 		for _, u := range macup.Updates {
 			if u.Name == updateName {
-				wg.Add(1)
-				go func(u macup.Update) {
-					defer wg.Done()
-					u.Run(buffers[u.Name])
-				}(u)
+				u.Run()
 			}
 		}
 	}
-
-	wg.Wait()
 
 	// Print the output of each update function
 	for _, updateName := range selectedUpdates {


### PR DESCRIPTION
Reverted to sequential processing as it maintains some of the command output format that was lost with concurrent processing. As well as safety issues with updating multiple things at once.

When we process sequential, colors of the command output are maintained And honestly I think it's safer to run sequentially so multiple things don't potentially break at once People can cancel if they want to stop the script at a certain point.